### PR TITLE
ci: detect upstream updates by commit ancestry

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -36,8 +36,8 @@ jobs:
         run: |
           LOCAL=$(git rev-parse HEAD)
           REMOTE=$(git rev-parse upstream/master)
-          if [ "$LOCAL" = "$REMOTE" ]; then
-            echo "No updates available (local: ${LOCAL:0:7}, remote: ${REMOTE:0:7})"
+          if git merge-base --is-ancestor upstream/master HEAD; then
+            echo "No updates available (upstream: ${REMOTE:0:7}, local: ${LOCAL:0:7})"
             echo "has_updates=false" >> "$GITHUB_OUTPUT"
           else
             echo "Updates available: ${LOCAL:0:7} -> ${REMOTE:0:7}"


### PR DESCRIPTION
## 问题

本仓库会在 ImmortalWrt 上游之上长期保留 XR1710G 专用提交，因此即使最新的 `upstream/master` 已经合入，`HEAD` 与上游分支尖端也不会相等。当前定时任务会把这种正常差异误判为有更新，随后执行一次空合并和无效推送。

现场记录：

- https://github.com/naoki66/ImmortalWrt-for-Gemtek-XR1710G/actions/runs/31425661296
- https://github.com/naoki66/ImmortalWrt-for-Gemtek-XR1710G/actions/runs/30947053568

两次运行都报告 `Updates available`，随后实际结果为 `Already up to date` / `Everything up-to-date`。

## 修改

用 `git merge-base --is-ancestor upstream/master HEAD` 判断上游提交是否已经包含在当前定制分支中：

- 已包含：设置 `has_updates=false`，跳过合并与推送
- 未包含：保留现有合并与推送流程

工作流已经使用 `fetch-depth: 0`，祖先关系判断所需的完整历史可用。

## 风险与回滚

改动只影响“是否需要同步”的判定，不改变 fetch、merge、冲突处理或 push 逻辑。若需回滚，撤销本 PR 的单个提交即可。

本 PR 与 #21、#22 相互独立，没有合并顺序要求。

## 验证

- 使用 Ruby YAML 解析工作流
- 运行 `git diff --check`
- 本地覆盖“上游已包含”和“上游有新提交”两种分支历史
