### PR TITLE
ci: propagate firmware build failures through tee

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -60,10 +60,12 @@ jobs:
         run: make download -j$(nproc)
 
       - name: Build Firmware
+        shell: bash
         run: |
           make -j2 world 2>&1 | tee build.log
 
       - name: Check build status
+        if: always()
         run: |
           if [ -f build.log ]; then
             tail -100 build.log
@@ -82,6 +84,7 @@ jobs:
         with:
           name: router-firmware
           path: |
+            build.log
             bin/targets/airoha/an7581/*.itb
             bin/targets/airoha/an7581/config.buildinfo
             bin/targets/airoha/an7581/feeds.buildinfo


### PR DESCRIPTION
## 根因

当前构建命令为：

```bash
make -j2 world 2>&1 | tee build.log
```

GitHub Actions 未显式指定 Bash 时，Linux runner 使用的命令行是 `bash -e`，管道退出状态取自最后一个命令 `tee`。因此 `make` 失败时，构建步骤仍可能显示成功。

## 修改

- 为固件构建步骤显式设置 `shell: bash`，让 GitHub Actions 启用 Bash 的 `-o pipefail`
- 为现有诊断步骤添加 `if: always()`，构建失败后仍输出目录和日志尾部
- 将完整 `build.log` 加入现有的 30 天构建产物

## 行为边界

成功构建和发布流程不变；失败构建会正确使 job 失败，但诊断信息与构建日志仍会保留。额外成本仅是上传 `build.log` 所占的产物空间。

若需回滚，撤销本 PR 的单个提交即可。本 PR 与 #20、#22 相互独立，没有合并顺序要求。

## 验证

- 使用 Ruby YAML 解析工作流
- 运行 `git diff --check`
- 验证同一失败管道在 `bash -e` 下返回成功、在 `bash -eo pipefail` 下返回失败
- 未触发完整固件构建；现有一次成功构建约需 2 小时
