### PR TITLE
docs: warn that sysupgrade does not retain extra packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@
 - 固件文件：`immortalwrt-airoha-an7581-gemtek_xr1710g-ubi-squashfs-sysupgrade.itb`
 - 升级方法：LuCI → 系统 → 备份/升级 → 刷写固件
 
+### 升级注意事项
+
+> [!WARNING]
+> LuCI 中的“保留配置”不会保留额外安装的软件包。升级前请备份配置并记录已安装的软件包；升级后需要
+> 重新安装 OpenClash、PassWall、AdGuard Home 等非预装组件。请使用与新固件匹配的软件包，不要恢复
+> 旧固件的 `kmod-*` 内核模块。
+
 ## 本地构建（可选）
 
 ```bash


### PR DESCRIPTION
## 背景

README 目前直接给出 LuCI 升级路径，但没有说明“保留配置”不会把额外安装的软件包一起写入新固件。#13 中维护者也已确认插件不会保留：

https://github.com/naoki66/ImmortalWrt-for-Gemtek-XR1710G/issues/13#issuecomment-5229347399

## 修改

在下载与升级说明旁增加警告，提醒用户：

- 升级前备份配置并记录额外安装的软件包
- 升级后重新安装 OpenClash、PassWall、AdGuard Home 等非预装组件
- 使用与新固件匹配的软件包，不恢复旧内核对应的 `kmod-*`

## 风险与回滚

仅修改 README，不影响固件、配置或工作流。警告位于升级入口旁，避免用户开始刷写后才发现插件缺失。

若需回滚，撤销本 PR 的单个提交即可。本 PR 与 #20、#21 相互独立，没有合并顺序要求。

## 验证

- 运行 `git diff --check`
- 检查 README 中“下载 → 升级注意事项 → 本地构建”的 Markdown 层级
