### PR TITLE
net: keep local bridge traffic off PPE bridge paths

### DIFF
--- a/target/linux/airoha/patches-6.18/9990-net-airoha-bind-WLAN-bound-flows-on-PPE-driver-L2-cache-miss.patch
+++ b/target/linux/airoha/patches-6.18/9990-net-airoha-bind-WLAN-bound-flows-on-PPE-driver-L2-cache-miss.patch
@@ -18,14 +18,15 @@ bridge device above the ingress netdev. If the PPE driver's L2 offload
 cache lookup misses, bind the hardware flow to the resolved WDMA or GDM
 egress path.
 
-Packets addressed to the ingress netdev itself are marked PACKET_HOST by
-eth_type_trans(). WiFi NPU/WED RX can call the PPE hook before
-eth_type_trans(), so classify local packets from the destination MAC when
-the ingress device and MAC header are available. They must not use the bridge
-L2 cache or fallback path:
-when a bridge and its port share a MAC address, the FDB can resolve that
-local address back to the ingress port and make PPE bind subsequent packets
-away from the CPU.
+Packets addressed to the ingress netdev or its bridge master must stay on
+the CPU. eth_type_trans() marks the former PACKET_HOST, but WiFi NPU/WED RX
+can call the PPE hook before it has run, so classify local packets from the
+destination MAC when the ingress device and MAC header are available.
+When the bridge master and port use different MAC addresses, checking only
+the ingress netdev misses traffic for the bridge host and can bind it away
+from the CPU. Resolve the master through a VLAN upper when present and treat
+both device addresses as local. These packets must not use the bridge L2
+cache or fallback path.
 
 Keep looking for a real L4 flowtable entry first so routed and NAT traffic
 whose next-hop MAC is local can still be offloaded. If no such entry
@@ -37,6 +38,10 @@ the default ppe_bind_rate of 30, while GDM4 counted the complete 5,318
 packets and reported no drops or errors. Raising ppe_bind_rate to 65,535
 prevented binding and delivered 5,206 of 5,207 packets, confirming the bad
 PPE bind.
+
+This also covers XR1710G deployments where WAN is a br-lan slave but has a
+different MAC from br-lan; otherwise TCP destined for the router can be
+installed as a bound PPE 5-tuple.
 
 Assisted-by: Codex:gpt-5.5
 Signed-off-by: Jihong Min <hurryman2212@gmail.com>
@@ -54,7 +59,7 @@ Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
 +#include <linux/etherdevice.h>
  #include <linux/ipv6.h>
  #include <linux/of_platform.h>
-@@ -708,65 +708,223 @@
+@@ -708,65 +708,234 @@
  }
  
  static int
@@ -263,7 +268,9 @@ Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
 +
 +static bool airoha_ppe_foe_skb_is_local(const struct sk_buff *skb)
 +{
++	struct net_device *master;
 +	const struct ethhdr *eh;
++	bool local;
 +
 +	/* NPU/WED RX may call PPE before eth_type_trans() has run. Keep
 +	 * unknown contexts local so a missing MAC header never enables the
@@ -273,7 +280,16 @@ Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
 +		return true;
 +
 +	eh = eth_hdr(skb);
-+	return ether_addr_equal_64bits(eh->h_dest, skb->dev->dev_addr);
++	if (ether_addr_equal_64bits(eh->h_dest, skb->dev->dev_addr))
++		return true;
++
++	rcu_read_lock();
++	master = airoha_ppe_foe_get_bridge_master_rcu(skb->dev);
++	local = master &&
++		ether_addr_equal_64bits(eh->h_dest, master->dev_addr);
++	rcu_read_unlock();
++
++	return local;
 +}
 +
  static void airoha_ppe_foe_insert_entry(struct airoha_ppe *ppe,
@@ -297,17 +313,17 @@ Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
  	spin_lock_bh(&ppe_lock);
  
  	hwe = airoha_ppe_foe_get_entry_locked(ppe, hash);
-@@ -903,2 +1062,3 @@ static void airoha_ppe_foe_insert_entry(
+@@ -903,2 +1073,3 @@ static void airoha_ppe_foe_insert_entry(
 -		if (!airoha_ppe_foe_compare_entry(e, hwe))
 +		if ((local && e->type == FLOW_TYPE_L2) ||
 +		    !airoha_ppe_foe_compare_entry(e, hwe))
  			continue;
-@@ -911,2 +1071,4 @@ static void airoha_ppe_foe_insert_entry(
+@@ -911,2 +1082,4 @@ static void airoha_ppe_foe_insert_entry(
  	if (commit_done)
  		goto unlock;
 +	if (local)
 +		goto unlock;
-@@ -917,2 +1077,4 @@ static void airoha_ppe_foe_insert_entry(
+@@ -917,2 +1088,4 @@ static void airoha_ppe_foe_insert_entry(
  	if (e)
  		airoha_ppe_foe_commit_subflow_entry(ppe, e, hash, rx_wlan);
 +	else if (bridge_ready)

--- a/target/linux/generic/pending-6.18/675-02-nft_flow_offload-add-bridging-support.patch
+++ b/target/linux/generic/pending-6.18/675-02-nft_flow_offload-add-bridging-support.patch
@@ -8,12 +8,18 @@ LAN port via br-lan), the flow offload engine only knows how to
 handle L3 routed traffic.
 
 This patch adds:
-- Bridge detection via FDB lookup (nft_flow_offload_is_bridging)
+- Bridge detection via non-local FDB lookup
+  (nft_flow_offload_is_bridging)
 - Separate route path for bridged traffic that uses in/out ifindex
   directly instead of L3 route lookup
 - MAC address extraction from ethernet header for bridged flows
 - VLAN-aware bridge support via bridge port VLAN context
 - Fix for VLAN untag underflow in nft_dev_path_info
+
+FDB entries marked BR_FDB_LOCAL terminate on the bridge host instead
+of being forwarded through a bridge port. Ignore those entries when
+selecting the bridge route so locally routed or NAT traffic keeps the
+normal routing path.
 
 Based on MediaTek SDK patch by Bo-Cun Chen <bc-bocun.chen@mediatek.com>.
 Adapted for Airoha AN7581 PPE offload.
@@ -33,7 +39,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  
  static enum flow_offload_xmit_type nft_xmit_type(struct dst_entry *dst)
  {
-@@ -41,7 +42,46 @@
+@@ -41,7 +42,48 @@
  	return true;
  }
  
@@ -56,6 +62,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
 +
 +static bool nft_flow_offload_is_bridging(struct sk_buff *skb)
 +{
++	struct net_bridge_fdb_entry *fdb;
 +	struct net_bridge_port *port;
 +	unsigned char *dmac = eth_hdr(skb)->h_dest;
 +	bool bridging = false;
@@ -68,7 +75,8 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
 +	port = br_port_get_rcu(skb->dev);
 +	if (port) {
 +		vlan_id = nft_flow_offload_get_vlan_id(port, skb);
-+		if (br_fdb_find_rcu(port->br, dmac, vlan_id))
++		fdb = br_fdb_find_rcu(port->br, dmac, vlan_id);
++		if (fdb && !test_bit(BR_FDB_LOCAL, &fdb->flags))
 +			bridging = true;
 +	}
 +	rcu_read_unlock();
@@ -81,7 +89,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  				     const struct dst_entry *dst_cache,
  				     const struct nf_conn *ct,
  				     enum ip_conntrack_dir dir, u8 *ha,
-@@ -57,6 +97,9 @@
+@@ -57,6 +99,9 @@
  		goto out;
  	}
  
@@ -91,7 +99,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  	n = dst_neigh_lookup(dst_cache, daddr);
  	if (!n)
  		return -1;
-@@ -71,7 +114,26 @@
+@@ -71,7 +116,26 @@
  		return -1;
  
  out:
@@ -119,7 +127,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  }
  
  struct nft_forward_info {
-@@ -100,12 +162,12 @@
+@@ -100,12 +164,12 @@
  
  	for (i = 0; i < stack->num_paths; i++) {
  		path = &stack->path[i];
@@ -133,7 +141,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  			if (is_zero_ether_addr(info->h_source))
  				memcpy(info->h_source, path->dev->dev_addr, ETH_ALEN);
  
-@@ -147,10 +209,8 @@
+@@ -147,10 +211,8 @@
  				info->num_encaps++;
  				break;
  			case DEV_PATH_BR_VLAN_UNTAG:
@@ -146,7 +154,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  				break;
  			case DEV_PATH_BR_VLAN_KEEP:
  				break;
-@@ -158,7 +218,6 @@
+@@ -158,7 +220,6 @@
  			info->xmit_type = FLOW_OFFLOAD_XMIT_DIRECT;
  			break;
  		default:
@@ -154,7 +162,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  			break;
  		}
  	}
-@@ -189,22 +248,45 @@
+@@ -189,22 +250,45 @@
  	return found;
  }
  
@@ -206,7 +214,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  
  	route->tuple[!dir].in.ifindex = info.indev->ifindex;
  	for (i = 0; i < info.num_encaps; i++) {
-@@ -221,11 +303,15 @@
+@@ -221,11 +305,15 @@
  		route->tuple[dir].out.hw_ifindex = info.hw_outdev->ifindex;
  		route->tuple[dir].xmit_type = info.xmit_type;
  	}
@@ -225,7 +233,7 @@ diff --git a/net/netfilter/nf_flow_table_path.c b/net/netfilter/nf_flow_table_pa
  {
  	struct dst_entry *this_dst = skb_dst(pkt->skb);
  	struct dst_entry *other_dst = NULL;
-@@ -265,12 +351,93 @@
+@@ -265,12 +353,93 @@
  	nft_default_forward_path(route, this_dst, dir);
  	nft_default_forward_path(route, other_dst, !dir);
  


### PR DESCRIPTION
Fixes #39

## Summary

- Ignore BR_FDB_LOCAL entries when nft_flow_offload classifies bridge traffic.
- Treat the bridge master MAC as local in the Airoha PPE L2 fallback.
- Preserve L4 routed/NAT offload and normal VLAN/bridge forwarding.

## Validation

- git diff --check
- Applied the 675-02/03/04 stack on Linux v6.18.44 sources.
- Applied the Airoha patch chain through 9990 and 9993 without rejects.